### PR TITLE
Update README.md - Adding Source Maps Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,24 @@ module.exports = {
 };
 ```
 
+## Source-maps:
+
+Notice that, in order to handle Source Maps properly, you also need to setup properly your CSS processor.
+The default cssProcessor is `cssnano` and the default configuration option is `{}`. As no `map` property is specified, it will probably not generate any intended Source Map.
+So, if you are using `cssnano` (default one) and want to support Source Maps, consider setting the `map` option with something like this:
+
+```javascript
+new OptimizeCSSAssetsPlugin({
+  cssProcessorOptions: {
+    map: {
+      inline: false
+    }
+  }
+})
+```
+
+Take a look at your cssProcessor docs for more ways to handle source-maps.
+
 ## License
 
 MIT (http://www.opensource.org/licenses/mit-license.php)


### PR DESCRIPTION
Just adding a Source Maps section to the README.md docs.

This is the result on the [issue #53](https://github.com/NMFR/optimize-css-assets-webpack-plugin/issues/53).

After some painful debugging section, I just realized that `optimize-css-assets-webpack-plugin` would pass cssProcessorOptions to `cssnano`, and the defaults used by this plugin would result in no source-maps.

This doc section can save some time for others that are using the default configuration and want to use source-maps, but don't know how it is truncated.

Anyway... it's open to discussion and improvements. Here it is.

